### PR TITLE
Adapt image names to apache predefined repo

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -1,0 +1,41 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+name: Check OpenServerless OpenWhisk 2 based images
+
+on: 
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  distdocker:
+    name: Build OpenServerless OpenWhisk 2 based images
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Remove unnecessary files
+        run: |
+          sudo rm -rf /usr/share/dotnet
+          sudo rm -rf "$AGENT_TOOLSDIRECTORY"    
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          submodules: recursive
+      - name: License
+        uses: apache/skywalking-eyes@main  

--- a/.github/workflows/distdocker.yml
+++ b/.github/workflows/distdocker.yml
@@ -59,11 +59,11 @@ jobs:
         run: |
           echo "REPO_URL=ghcr.io" >> "$GITHUB_ENV"
           echo "DOCKER_REGISTRY=ghcr.io/${{ github.repository_owner }}" >> "$GITHUB_ENV"
-      - name: Use dockerhub
+      - name: Use registry.hub.docker.com
         if:  ${{ github.repository_owner == 'apache'}}
         run: |
           echo "REPO_URL=registry.hub.docker.com" >> "$GITHUB_ENV"
-          echo "DOCKER_REGISTRY=registry.hub.docker.com" >> "$GITHUB_ENV"         
+          echo "DOCKER_REGISTRY=registry.hub.docker.com/apache" >> "$GITHUB_ENV"         
       - name: Registry login
         uses: docker/login-action@v3
         if:  ${{ github.repository_owner != 'apache' }}

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -21,18 +21,17 @@ dotenv:
   - .env
 
 vars:
-  BASETAG: 2.0.0-ops-incubating
+  BASETAG: 2.0.0-incubating
   TAG:
     sh: git describe --tags --abbrev=0 2>/dev/null || git rev-parse --short HEAD
   GHUSER:
     sh: echo "${GITHUB_USER:-apache}"
-  DOCKER_REGISTRY:
-    sh: echo "${GITHUB_USER:-apache}"
-  CONTROLLER_IMAGE: openwhisk2-controller
-  INVOKER_IMAGE: openwhisk2-invoker
-  SCHEDULER_IMAGE: openwhisk2-scheduler
-  STANDALONE_IMAGE: openwhisk2-standalone
-  COMMON_IMAGE: openwhisk2-scala
+  DOCKER_REGISTRY: registry.hub.docker.com/apache
+  CONTROLLER_IMAGE: openserverless-wsk-controller
+  INVOKER_IMAGE: openserverless-wsk-invoker
+  SCHEDULER_IMAGE: openserverless-wsk-scheduler
+  STANDALONE_IMAGE: openserverless-wsk-standalone
+  COMMON_IMAGE: openserverless-wsk-scala
   ACT: "nothing"
   S: ""
 


### PR DESCRIPTION
This PR contributes a small change to the Openserverless build project adapting the name of the generated Openwhisk 2 images to these predefined names:

- openserverless-wsk-scala
- openserverless-wsk-controller
- openserverless-wsk-invoker
- openserverless-wsk-scheduler
- openserverless-wsk-standalone