### PR TITLE
Ensure standalone is built from Openwhisk provided Dockerfile

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -213,7 +213,7 @@ tasks:
     cmds:
       - task: docker-build
         vars:
-          DIR: standalone
+          DIR: openwhisk/core/standalone
           IMG: "{{.DOCKER_REGISTRY}}/${MY_STANDALONE_IMAGE:-{{.STANDALONE_IMAGE}}}:{{.TAG}}"
           ACT: '{{.ACT}}'
           BASE: "{{.DOCKER_REGISTRY}}/{{.COMMON_IMAGE}}:{{.TAG}}"

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -166,6 +166,25 @@ tasks:
       (*) echo ACT must be "build|buildx|buildx-push"
       esac
 
+  # this requires ACT IMG OPENWHISK_JAR and DIR parameters to be passed 
+  docker-build-standalone:
+    silent: true
+    cmds:
+    - |-
+      echo "***" {{.ACT}} for {{.IMG}} in {{.DIR}}
+      case "{{.ACT}}" in
+      (build)
+      docker build {{.DIR}} -t {{.IMG}} --build-arg BASE={{.BASE}} --build-arg OPENWHISK_JAR={{.OPENWHISK_JAR}} --push
+      ;;
+      (buildx) 
+      docker buildx build --platform linux/amd64,linux/arm64 --build-arg OPENWHISK_JAR={{.OPENWHISK_JAR}} -t {{.IMG}} {{.DIR}}
+      ;;
+      (buildx-push) 
+      docker buildx build --platform linux/amd64,linux/arm64 --build-arg OPENWHISK_JAR={{.OPENWHISK_JAR}} -t {{.IMG}} {{.DIR}} --push 
+      ;;
+      (*) echo ACT must be "build|buildx|buildx-push"
+      esac      
+
   build:scala:
     cmds:
       - task: docker-build
@@ -211,12 +230,13 @@ tasks:
     deps:
     - compile:standalone
     cmds:
-      - task: docker-build
+      - task: docker-build-standalone
         vars:
           DIR: openwhisk/core/standalone
           IMG: "{{.DOCKER_REGISTRY}}/${MY_STANDALONE_IMAGE:-{{.STANDALONE_IMAGE}}}:{{.TAG}}"
           ACT: '{{.ACT}}'
           BASE: "{{.DOCKER_REGISTRY}}/{{.COMMON_IMAGE}}:{{.TAG}}"
+          OPENWHISK_JAR: "build/libs/openwhisk-standalone-1.0.1-SNAPSHOT.jar"
   
   build-all:
     cmds:

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -177,10 +177,10 @@ tasks:
       docker build {{.DIR}} -t {{.IMG}} --build-arg BASE={{.BASE}} --build-arg OPENWHISK_JAR={{.OPENWHISK_JAR}} --push
       ;;
       (buildx) 
-      docker buildx build --platform linux/amd64,linux/arm64 --build-arg OPENWHISK_JAR={{.OPENWHISK_JAR}} -t {{.IMG}} {{.DIR}}
+      docker buildx build --platform linux/amd64,linux/arm64 --build-arg BASE={{.BASE}} --build-arg OPENWHISK_JAR={{.OPENWHISK_JAR}} -t {{.IMG}} {{.DIR}}
       ;;
       (buildx-push) 
-      docker buildx build --platform linux/amd64,linux/arm64 --build-arg OPENWHISK_JAR={{.OPENWHISK_JAR}} -t {{.IMG}} {{.DIR}} --push 
+      docker buildx build --platform linux/amd64,linux/arm64 --build-arg BASE={{.BASE}} --build-arg OPENWHISK_JAR={{.OPENWHISK_JAR}} -t {{.IMG}} {{.DIR}} --push 
       ;;
       (*) echo ACT must be "build|buildx|buildx-push"
       esac      


### PR DESCRIPTION
This PR ensure that also the openwhisk standalone image is built using the Openwhisk provided Dockerfile, instead of using a custom one. 